### PR TITLE
Revert "Update all non-major dependencies"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ gitdb==4.0.9
 GitPython==3.1.27
 importlib-metadata==4.12.0
 Jinja2==3.1.2
-Markdown==3.4.1
+Markdown==3.3.7
 MarkupSafe==2.1.1
 mergedeep==1.3.4
 mkdocs==1.3.1
@@ -25,4 +25,4 @@ pyyaml_env_tag==0.1
 six==1.16.0
 smmap==5.0.0
 watchdog==2.1.9
-zipp==3.8.1
+zipp==3.8.0


### PR DESCRIPTION
以下のエラーのため、一旦Revertします！

```bash
ERROR: Cannot install -r requirements.txt (line 11) and Markdown==3.4.1 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested Markdown==3.4.1
    mkdocs 1.3.1 depends on Markdown<3.4 and >=3.2.1

To fix this you could try to:
1. loosen the range of package versions you've specified
ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
2. remove package versions to allow pip attempt to solve the dependency conflict
```